### PR TITLE
Update docs to match openapi server URL

### DIFF
--- a/CUSTOMGPT_DEPLOYMENT_ASSISTANT.md
+++ b/CUSTOMGPT_DEPLOYMENT_ASSISTANT.md
@@ -11,7 +11,7 @@ DEPLOYMENT COMMANDS:
   1. Guide them to: cd /workspaces/aquil-symbolic-engine/worker
   2. Run: ./deploy.sh
   3. If that fails, try: wrangler deploy
-  4. Check status at: https://signal_q.workers.dev
+  4. Check status at: https://signal_q.catnip-pieces1.workers.dev
 
 DEPLOYMENT TROUBLESHOOTING:
 - If browser login fails: "The browser timeout is known. Try: wrangler login --no-browser"
@@ -48,7 +48,7 @@ Want me to check if it's working after deployment?"
 
 **You say:** "Is my API working?"
 **CustomGPT responds:**
-"Let me check your Signal Q deployment at https://signal_q.workers.dev..."
+"Let me check your Signal Q deployment at https://signal_q.catnip-pieces1.workers.dev..."
 
 ### **4. Smart Deployment Reminders**
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ wrangler login && wrangler deploy
 - **Admin Token**: `sq_admin_9x7c5v1b3n6m8k2q4w7e9r5t3y8u1i6o`
 
 ## 🎯 **For CustomGPT**
-- **Base URL**: `https://signal_q.workers.dev`
+ - **Base URL**: `https://signal_q.catnip-pieces1.workers.dev`
 - **Auth**: Bearer `sq_live_7k9m2n8p4x6w1z5q3r7t9v2b4c6d8f0h`
 - **Schema**: Upload `worker/src/openapi.json`
 

--- a/worker/deploy.sh
+++ b/worker/deploy.sh
@@ -22,10 +22,10 @@ wrangler deploy
 
 echo ""
 echo "✅ Deployment complete!"
-echo "🔗 Your API is available at: https://signal_q.workers.dev"
+echo "🔗 Your API is available at: https://signal_q.catnip-pieces1.workers.dev"
 echo ""
 echo "🔧 Next steps:"
 echo "  1. Update KV namespace ID in wrangler.toml"
 echo "  2. Change API tokens from 'changeme' to secure values"
-echo "  3. Test endpoints at https://signal_q.workers.dev"
+echo "  3. Test endpoints at https://signal_q.catnip-pieces1.workers.dev"
 echo ""


### PR DESCRIPTION
## Summary
- update README and docs to use `signal_q.catnip-pieces1.workers.dev`
- update deployment script message with new URL

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_688b1ee9bb3c8325bbc0cc8c82bc21c0