### PR TITLE
ci: add deploy workflow with smoke tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy Worker
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+        if: ${{ hashFiles('package-lock.json') != '' }}
+      - name: Wrangler Auth
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ -z "$CLOUDFLARE_API_TOKEN" ]; then echo "Missing CLOUDFLARE_API_TOKEN"; exit 1; fi
+          echo "Auth OK"
+      - name: Deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy
+
+      - name: Smoke tests
+        run: ./scripts/smoke.sh
+        env:
+          SIGNALQ_API_TOKEN: ${{ secrets.SIGNALQ_API_TOKEN }}

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,88 +1,22 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+BASE="${1:-https://signal-q.me}"
+TOKEN="${SIGNALQ_API_TOKEN:-}"
 
-# Signal Q Smoke Test Script
-# Tests the basic health and version endpoints
+echo "Health"
+curl -sSf "$BASE/system/health" | jq .
 
-set -e
+echo "Version"
+curl -sSf "$BASE/version" | jq .
 
-# Environment variables with defaults
-BASE="${BASE:-https://signal-q.me}"
-TOKEN="${TOKEN:-}"
+echo "Spec"
+curl -sSf "$BASE/openapi.yaml" > /dev/null
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+echo "Actions list"
+curl -sSf -H "Authorization: Bearer $TOKEN" "$BASE/actions/list" | jq .
 
-echo "🚀 Signal Q Smoke Test"
-echo "Base URL: $BASE"
-if [ -n "$TOKEN" ]; then
-    echo "API Token: ${TOKEN:0:10}..." # Show only first 10 chars
-else
-    echo "API Token: Not provided"
-fi
-echo ""
-
-# Check if API token is provided
-if [ -z "$TOKEN" ]; then
-    echo -e "${RED}❌ Error: TOKEN environment variable is required${NC}"
-    echo "Example: export TOKEN=\$SIGNALQ_API_TOKEN"
-    exit 1
-fi
-
-# Test 1: Version endpoint (no auth required)
-echo "📋 Testing GET /version (no auth)..."
-VERSION_RESPONSE=$(curl -s -w "HTTPSTATUS:%{http_code}" "$BASE/version")
-VERSION_STATUS=$(echo "$VERSION_RESPONSE" | grep -o "HTTPSTATUS:[0-9]*" | cut -d: -f2)
-VERSION_BODY=$(echo "$VERSION_RESPONSE" | sed 's/HTTPSTATUS:[0-9]*$//')
-
-if [ "$VERSION_STATUS" != "200" ]; then
-    echo -e "${RED}❌ Version endpoint failed with status $VERSION_STATUS${NC}"
-    echo "Response: $VERSION_BODY"
-    exit 1
-fi
-
-# Parse version response
-VERSION=$(echo "$VERSION_BODY" | grep -o '"version":"[^"]*' | cut -d'"' -f4)
-if [ -z "$VERSION" ]; then
-    echo -e "${RED}❌ Version endpoint returned invalid JSON${NC}"
-    echo "Response: $VERSION_BODY"
-    exit 1
-fi
-
-echo -e "${GREEN}✅ Version endpoint OK (version: $VERSION)${NC}"
-echo ""
-
-# Test 2: Health endpoint (requires auth)
-echo "🏥 Testing POST /actions/system_health (with Bearer auth)..."
-HEALTH_RESPONSE=$(curl -s -w "HTTPSTATUS:%{http_code}" \
-    -X POST \
-    -H "Authorization: Bearer $TOKEN" \
-    "$BASE/actions/system_health")
-HEALTH_STATUS=$(echo "$HEALTH_RESPONSE" | grep -o "HTTPSTATUS:[0-9]*" | cut -d: -f2)
-HEALTH_BODY=$(echo "$HEALTH_RESPONSE" | sed 's/HTTPSTATUS:[0-9]*$//')
-
-if [ "$HEALTH_STATUS" != "200" ]; then
-    echo -e "${RED}❌ Health endpoint failed with status $HEALTH_STATUS${NC}"
-    echo "Response: $HEALTH_BODY"
-    exit 1
-fi
-
-# Parse health response - new schema expects "status" field
-HEALTH_STATUS_VALUE=$(echo "$HEALTH_BODY" | grep -o '"status":"[^"]*' | cut -d'"' -f4)
-if [ "$HEALTH_STATUS_VALUE" != "healthy" ]; then
-    echo -e "${RED}❌ Health check failed - status is '$HEALTH_STATUS_VALUE' (expected 'healthy')${NC}"
-    echo "Response: $HEALTH_BODY"
-    exit 1
-fi
-
-echo -e "${GREEN}✅ Health endpoint OK (status: $HEALTH_STATUS_VALUE)${NC}"
-echo ""
-
-# Summary
-echo -e "${GREEN}🎉 All smoke tests passed!${NC}"
-echo "✅ Version endpoint: $VERSION"
-echo "✅ Health status: $HEALTH_STATUS_VALUE"
-echo ""
-echo "Signal Q API is healthy and responding correctly."
+echo "Chat (protected)"
+curl -sSf -H "Authorization: Bearer $TOKEN" \
+  -H "content-type: application/json" \
+  -d '{"user":"aquil","prompt":"ping"}' \
+  "$BASE/actions/chat" | jq .


### PR DESCRIPTION
## Summary
- add deployment workflow using Wrangler
- run shared smoke script that exercises health, version, spec, actions list, and chat endpoints

## Testing
- `npm test`
- `SIGNALQ_API_TOKEN=dummy ./scripts/smoke.sh` *(fails: The requested URL returned error: 403)*


------
https://chatgpt.com/codex/tasks/task_e_689a8622889c8325a9e924a090dd1fa1