### PR TITLE
Use Workers AI gateway for Llama model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,13 +19,13 @@ NODE_ENV=development
 
 # === CLOUDFLARE CONFIGURATION ===
 # Account ID for Cloudflare Workers (optional for local dev)
-CLOUDFLARE_ACCOUNT_ID=00000000000000000000000000000000
+CLOUDFLARE_ACCOUNT_ID=b07412f2f2389e8b537051bc092f3376
 
 # Gateway ID for Cloudflare AI Gateway (optional for local dev)
-CLOUDFLARE_GATEWAY_ID=signalq-dev
+CLOUDFLARE_GATEWAY_ID=ark-ai
 
 # Model ID for Workers AI requests (optional for local dev)
-CLOUDFLARE_MODEL_ID=@cf/meta/llama-2-7b-chat-int8
+CLOUDFLARE_MODEL_ID=@cf/meta/llama-3.1-8b-instruct
 
 # API Token for Cloudflare Workers (optional for local dev)
 CLOUDFLARE_API_TOKEN=cf_api_token_example

--- a/API_EXAMPLES.md
+++ b/API_EXAMPLES.md
@@ -21,7 +21,7 @@ curl https://signal-q.me/version
 
 ```bash
 # Health check with USER token
-curl -H "Authorization: Bearer sq_live_7k9m2n8p4x6w1z5q3r7t9v2b4c6d8f0h" \
+curl -H "Authorization: Bearer $SIGNALQ_API_TOKEN" \
   https://signal-q.me/system/health
 
 # Expected response:
@@ -55,13 +55,13 @@ curl -X POST \
 ```bash
 # List all available actions
 curl -X POST \
-  -H "Authorization: Bearer sq_live_7k9m2n8p4x6w1z5q3r7t9v2b4c6d8f0h" \
+  -H "Authorization: Bearer $SIGNALQ_API_TOKEN" \
   -H "Content-Type: application/json" \
   https://signal-q.me/actions/list
 
 # Probe identity
 curl -X POST \
-  -H "Authorization: Bearer sq_live_7k9m2n8p4x6w1z5q3r7t9v2b4c6d8f0h" \
+  -H "Authorization: Bearer $SIGNALQ_API_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"context": "testing"}' \
   https://signal-q.me/actions/probe_identity
@@ -76,10 +76,10 @@ curl -X POST \
 const SignalQClient = require('./sdk/signal-q-client.js');
 
 // Create client instance
-const client = new SignalQClient({
-  baseUrl: 'https://signal-q.me',
-  token: 'sq_live_7k9m2n8p4x6w1z5q3r7t9v2b4c6d8f0h'
-});
+  const client = new SignalQClient({
+    baseUrl: 'https://signal-q.me',
+    token: process.env.SIGNALQ_API_TOKEN
+  });
 
 // Basic operations
 async function basicExample() {
@@ -106,11 +106,11 @@ async function basicExample() {
 
 ```javascript
 async function advancedExample() {
-  const client = new SignalQClient({
-    baseUrl: 'https://signal-q.me',
-    token: 'sq_live_7k9m2n8p4x6w1z5q3r7t9v2b4c6d8f0h',
-    timeout: 10000 // 10 second timeout
-  });
+    const client = new SignalQClient({
+      baseUrl: 'https://signal-q.me',
+      token: process.env.SIGNALQ_API_TOKEN,
+      timeout: 10000 // 10 second timeout
+    });
 
   try {
     // List all available actions
@@ -155,10 +155,10 @@ async function advancedExample() {
     <script src="./sdk/signal-q-client.js"></script>
     <script>
         async function testAPI() {
-            const client = new SignalQClient({
-                baseUrl: 'https://signal-q.me',
-                token: 'sq_live_7k9m2n8p4x6w1z5q3r7t9v2b4c6d8f0h'
-            });
+              const client = new SignalQClient({
+                  baseUrl: 'https://signal-q.me',
+                  token: process.env.SIGNALQ_API_TOKEN
+              });
             
             const output = document.getElementById('output');
             
@@ -215,6 +215,7 @@ async function errorHandlingExample() {
 ## 🐍 Python Examples
 
 ```python
+import os
 import requests
 import json
 
@@ -257,7 +258,7 @@ class SignalQClient:
 def main():
     client = SignalQClient(
         base_url='https://signal-q.me',
-        token='sq_live_7k9m2n8p4x6w1z5q3r7t9v2b4c6d8f0h'
+        token=os.environ.get('SIGNALQ_API_TOKEN')
     )
     
     try:
@@ -296,7 +297,7 @@ if __name__ == '__main__':
 # health-check.sh - Comprehensive API health verification
 
 BASE_URL="https://signal-q.me"
-TOKEN="sq_live_7k9m2n8p4x6w1z5q3r7t9v2b4c6d8f0h"
+TOKEN="$SIGNALQ_API_TOKEN"
 
 echo "🏥 Signal Q Health Check"
 echo "======================="
@@ -350,7 +351,7 @@ echo -e "\n🎉 All health checks passed!"
 # batch-operations.sh - Perform multiple API operations
 
 BASE_URL="https://signal-q.me"
-TOKEN="sq_live_7k9m2n8p4x6w1z5q3r7t9v2b4c6d8f0h"
+TOKEN="$SIGNALQ_API_TOKEN"
 
 echo "🔄 Batch Operations"
 echo "=================="
@@ -395,7 +396,7 @@ describe('Signal Q API', () => {
   beforeEach(() => {
     client = new SignalQClient({
       baseUrl: process.env.TEST_BASE_URL || 'http://localhost:8788',
-      token: 'sq_live_7k9m2n8p4x6w1z5q3r7t9v2b4c6d8f0h'
+      token: process.env.SIGNALQ_API_TOKEN
     });
   });
 

--- a/CLOUDFLARE_SETUP.md
+++ b/CLOUDFLARE_SETUP.md
@@ -47,15 +47,21 @@ wrangler login
 The login opens a browser window and stores your API credentials locally.
 
 ## 4. Configure secrets
-Set the API token used by the worker for authenticated requests:
+Set the worker tokens and Cloudflare AI gateway credentials:
 ```bash
 wrangler secret put SIGNALQ_API_TOKEN
+wrangler secret put SIGNALQ_ADMIN_TOKEN
+wrangler secret put CLOUDFLARE_API_TOKEN
 ```
-Export the same token locally so the deploy script can perform a health check:
+Export the related environment variables so the deploy script and `/actions/chat` can access them:
 ```bash
-export SIGNALQ_API_TOKEN=<your token>
+export SIGNALQ_API_TOKEN=<your user token>
+export SIGNALQ_ADMIN_TOKEN=<your admin token>
+export CLOUDFLARE_ACCOUNT_ID=<your Cloudflare account ID>
+export CLOUDFLARE_GATEWAY_ID=<your AI Gateway ID>
+export CLOUDFLARE_MODEL_ID=@cf/meta/llama-3.1-8b-instruct
 ```
-The worker reads the secret at runtime and the environment variable is only used during deployment.
+The worker reads the secrets at runtime; the environment variables are only used during deployment or local testing.
 
 ## 5. Deploy the worker
 From the project root run the deploy script:
@@ -74,8 +80,8 @@ routes = [
 ```
 Update the pattern if you want to use a different domain. The domain must exist in your Cloudflare account and have a DNS record pointing at Workers.
 
-If your project uses CI/CD you can deploy non-interactively by setting the `CF_API_TOKEN` and
-`CF_ACCOUNT_ID` environment variables before running `wrangler deploy`.
+If your project uses CI/CD you can deploy non-interactively by setting the `CLOUDFLARE_API_TOKEN` and
+`CLOUDFLARE_ACCOUNT_ID` environment variables before running `wrangler deploy`.
 
 ## 7. Verify deployment
 After deployment you can run the smoke tests:

--- a/README.md
+++ b/README.md
@@ -12,20 +12,29 @@ Signal Q is a Cloudflare Worker that exposes a minimal API for version info, hea
 - `wrangler secret put SIGNALQ_ADMIN_TOKEN`
 
 ## Workers AI Gateway
-Set these to enable `/actions/chat` to call Cloudflare Workers AI via the Gateway's OpenAI-compatible [Chat Completions](https://developers.cloudflare.com/ai-gateway/chat-completion/) endpoint:
+Set these to enable `/actions/chat` to call Cloudflare Workers AI via the Gateway:
 
-- `CLOUDFLARE_ACCOUNT_ID`
-- `CLOUDFLARE_GATEWAY_ID`
-- `CLOUDFLARE_MODEL_ID` (for example `@cf/meta/llama-2-7b-chat-int8`)
+- `CLOUDFLARE_ACCOUNT_ID` (e.g. `b07412f2f2389e8b537051bc092f3376`)
+- `CLOUDFLARE_GATEWAY_ID` (e.g. `ark-ai`)
+- `CLOUDFLARE_MODEL_ID` (e.g. `@cf/meta/llama-3.1-8b-instruct`)
 - `wrangler secret put CLOUDFLARE_API_TOKEN`
 
 The worker posts prompts to:
 
 ```
-https://gateway.ai.cloudflare.com/v1/${CLOUDFLARE_ACCOUNT_ID}/${CLOUDFLARE_GATEWAY_ID}/chat/completions
+https://gateway.ai.cloudflare.com/v1/${CLOUDFLARE_ACCOUNT_ID}/${CLOUDFLARE_GATEWAY_ID}/workers-ai/${CLOUDFLARE_MODEL_ID}
 ```
 
-and expects an OpenAI-style response, falling back to an echo reply if the request fails.
+Example curl request:
+
+```
+curl https://gateway.ai.cloudflare.com/v1/b07412f2f2389e8b537051bc092f3376/ark-ai/workers-ai/@cf/meta/llama-3.1-8b-instruct \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  --header 'Content-Type: application/json' \
+  --data '{"prompt": "What is Cloudflare?"}'
+```
+
+The worker falls back to an echo reply if the request fails.
 
 If any are missing the chat action falls back to echo responses.
 

--- a/worker/index.js
+++ b/worker/index.js
@@ -85,8 +85,8 @@ export default {
     // Auth for /actions/*
     const bearer = request.headers.get('authorization') || '';
     const token = bearer.startsWith('Bearer ') ? bearer.slice(7) : null;
-    const userToken = env.USER_TOKEN || 'sq_live_7k9m2n8p4x6w1z5q3r7t9v2b4c6d8f0h';
-    const adminToken = env.ADMIN_TOKEN || 'sq_admin_9x7c5v1b3n6m8k2q4w7e9r5t3y8u1o6p2';
+    const userToken = env.SIGNALQ_API_TOKEN || 'sq_live_7k9m2n8p4x6w1z5q3r7t9v2b4c6d8f0h';
+    const adminToken = env.SIGNALQ_ADMIN_TOKEN || 'sq_admin_9x7c5v1b3n6m8k2q4w7e9r5t3y8u1o6p2';
 
     if (path.startsWith('/actions/')) {
       if (!token || (token !== userToken && token !== adminToken)) {
@@ -114,26 +114,22 @@ export default {
 
         if (env.CLOUDFLARE_API_TOKEN && env.CLOUDFLARE_ACCOUNT_ID && env.CLOUDFLARE_GATEWAY_ID && env.CLOUDFLARE_MODEL_ID && prompt) {
           try {
-            const endpoint = `https://gateway.ai.cloudflare.com/v1/${env.CLOUDFLARE_ACCOUNT_ID}/${env.CLOUDFLARE_GATEWAY_ID}/chat/completions`;
+            const endpoint = `https://gateway.ai.cloudflare.com/v1/${env.CLOUDFLARE_ACCOUNT_ID}/${env.CLOUDFLARE_GATEWAY_ID}/workers-ai/${env.CLOUDFLARE_MODEL_ID}`;
             const r = await fetch(endpoint, {
               method: 'POST',
               headers: {
                 'authorization': `Bearer ${env.CLOUDFLARE_API_TOKEN}`,
                 'content-type': 'application/json'
               },
-              body: JSON.stringify({
-                model: env.CLOUDFLARE_MODEL_ID,
-                messages: [{ role: 'user', content: prompt }]
-              })
+              body: JSON.stringify({ prompt })
             });
             const data = await r.json();
-            const text = data.choices?.[0]?.message?.content;
+            const text = data.result?.response;
             if (text) {
               reply = { text, model: env.CLOUDFLARE_MODEL_ID };
             }
           } catch (err) {
             // Fallback to echo if Cloudflare call fails
-            reply = { text: `ACK: ${prompt}`.trim(), model: 'signal-q:echo' };
           }
         }
 


### PR DESCRIPTION
## Summary
- document Cloudflare account, gateway, and model IDs with curl example using `CLOUDFLARE_API_TOKEN`
- align worker auth to `SIGNALQ_API_TOKEN`/`SIGNALQ_ADMIN_TOKEN` and refresh `.env.example` with gateway details
- clarify Cloudflare setup and replace hard-coded tokens in API examples with environment variables

## Testing
- `npm test`
- `node scripts/secret-scan.cjs`


------
https://chatgpt.com/codex/tasks/task_e_689edd6721008325a6fd3a821df7f246