### PR TITLE
Integrate Cloudflare Workers AI via Gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,16 +19,16 @@ NODE_ENV=development
 
 # === CLOUDFLARE CONFIGURATION ===
 # Account ID for Cloudflare Workers (optional for local dev)
-CLOUDFLARE_ACCOUNT_ID=b07412f2f2389e8b537051bc092f3376
+CLOUDFLARE_ACCOUNT_ID=acme-123456
 
 # Gateway ID for Cloudflare AI Gateway (optional for local dev)
-CLOUDFLARE_GATEWAY_ID=ark-ai
+CLOUDFLARE_GATEWAY_ID=gateway-abcdef
 
 # Model ID for Workers AI requests (optional for local dev)
-CLOUDFLARE_MODEL_ID=@cf/meta/llama-3.1-8b-instruct
+CLOUDFLARE_MODEL_ID=@cf/meta/llama-2-7b-chat-int8
 
 # API Token for Cloudflare Workers (optional for local dev)
-CLOUDFLARE_API_TOKEN=cf_api_token_example
+CLOUDFLARE_API_TOKEN=cf_example_token
 
 # === PRODUCTION SECRETS SETUP ===
 # Do NOT put production secrets in this file!

--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,7 @@ build/
 tmp/
 temp/
 
+# Memory logs
+memory/log.json
+
 

--- a/CLOUDFLARE_SETUP.md
+++ b/CLOUDFLARE_SETUP.md
@@ -59,7 +59,7 @@ export SIGNALQ_API_TOKEN=<your user token>
 export SIGNALQ_ADMIN_TOKEN=<your admin token>
 export CLOUDFLARE_ACCOUNT_ID=<your Cloudflare account ID>
 export CLOUDFLARE_GATEWAY_ID=<your AI Gateway ID>
-export CLOUDFLARE_MODEL_ID=@cf/meta/llama-3.1-8b-instruct
+export CLOUDFLARE_MODEL_ID=@cf/meta/llama-2-7b-chat-int8
 ```
 The worker reads the secrets at runtime; the environment variables are only used during deployment or local testing.
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Signal Q is a Cloudflare Worker that exposes a minimal API for version info, hea
 ## Workers AI Gateway
 Set these to enable `/actions/chat` to call Cloudflare Workers AI via the Gateway:
 
-- `CLOUDFLARE_ACCOUNT_ID` (e.g. `b07412f2f2389e8b537051bc092f3376`)
-- `CLOUDFLARE_GATEWAY_ID` (e.g. `ark-ai`)
-- `CLOUDFLARE_MODEL_ID` (e.g. `@cf/meta/llama-3.1-8b-instruct`)
+- `CLOUDFLARE_ACCOUNT_ID` (e.g. `acme-123456`)
+- `CLOUDFLARE_GATEWAY_ID` (e.g. `gateway-abcdef`)
+- `CLOUDFLARE_MODEL_ID` (e.g. `@cf/meta/llama-2-7b-chat-int8`)
 - `wrangler secret put CLOUDFLARE_API_TOKEN`
 
 The worker posts prompts to:
@@ -28,10 +28,10 @@ https://gateway.ai.cloudflare.com/v1/${CLOUDFLARE_ACCOUNT_ID}/${CLOUDFLARE_GATEW
 Example curl request:
 
 ```
-curl https://gateway.ai.cloudflare.com/v1/b07412f2f2389e8b537051bc092f3376/ark-ai/workers-ai/@cf/meta/llama-3.1-8b-instruct \
+curl https://gateway.ai.cloudflare.com/v1/acme-123456/gateway-abcdef/workers-ai/@cf/meta/llama-2-7b-chat-int8 \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header 'Content-Type: application/json' \
-  --data '{"prompt": "What is Cloudflare?"}'
+  --data '{"input": "What is Cloudflare?"}'
 ```
 
 The worker falls back to an echo reply if the request fails.

--- a/tests/actions.spec.js
+++ b/tests/actions.spec.js
@@ -1,5 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import worker from '../worker/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const LOG_PATH = path.join(__dirname, '..', 'memory', 'log.json');
 
 async function call(path, init = {}) {
   const url = `https://example.test${path}`;
@@ -25,7 +32,11 @@ describe('actions API', () => {
   });
 
   describe('chat', () => {
-    it('echoes the provided prompt', async () => {
+    beforeEach(async () => {
+      await fs.rm(LOG_PATH, { force: true });
+    });
+
+    it('echoes the provided prompt and logs interaction', async () => {
       const res = await call('/actions/chat', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
@@ -35,6 +46,10 @@ describe('actions API', () => {
       const data = await res.json();
       expect(data.ok).toBe(true);
       expect(data.reply.text).toBe('ACK: hello');
+      const logRaw = await fs.readFile(LOG_PATH, 'utf8');
+      const log = JSON.parse(logRaw);
+      expect(log.length).toBe(1);
+      expect(log[0].input).toBe('hello');
     });
 
     it('rejects requests without valid token', async () => {

--- a/worker/index.js
+++ b/worker/index.js
@@ -34,6 +34,28 @@ async function appendMemory(env, user, payload) {
   });
 }
 
+// Local file-based memory log for Node.js environments
+async function appendLog(entry) {
+  try {
+    if (typeof process === 'undefined' || !process.versions?.node) return;
+    const { promises: fs } = await import('fs');
+    const path = await import('path');
+    const { fileURLToPath } = await import('url');
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = path.dirname(__filename);
+    const logPath = path.join(__dirname, '..', 'memory', 'log.json');
+    await fs.mkdir(path.dirname(logPath), { recursive: true });
+    let items = [];
+    try {
+      const existing = await fs.readFile(logPath, 'utf8');
+      items = JSON.parse(existing);
+      if (!Array.isArray(items)) items = [];
+    } catch {}
+    items.push(entry);
+    await fs.writeFile(logPath, JSON.stringify(items, null, 2));
+  } catch {}
+}
+
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
@@ -111,6 +133,7 @@ export default {
         const prompt = typeof body.prompt === 'string' ? body.prompt : '';
 
         let reply = { text: `ACK: ${prompt}`.trim(), model: 'signal-q:echo' };
+        let data;
 
         if (env.CLOUDFLARE_API_TOKEN && env.CLOUDFLARE_ACCOUNT_ID && env.CLOUDFLARE_GATEWAY_ID && env.CLOUDFLARE_MODEL_ID && prompt) {
           try {
@@ -121,10 +144,10 @@ export default {
                 'authorization': `Bearer ${env.CLOUDFLARE_API_TOKEN}`,
                 'content-type': 'application/json'
               },
-              body: JSON.stringify({ prompt })
+              body: JSON.stringify({ input: prompt })
             });
-            const data = await r.json();
-            const text = data.result?.response;
+            data = await r.json();
+            const text = data.result?.text;
             if (text) {
               reply = { text, model: env.CLOUDFLARE_MODEL_ID };
             }
@@ -139,6 +162,8 @@ export default {
           // If memory fails, still surface a clear error with correlation id
           return withCID(json({ ok: false, error: 'Memory append failed', detail: String(e) }, { status: 500, headers: corsHeaders() }));
         }
+
+        await appendLog({ timestamp: Date.now(), input: prompt, output: data || reply });
 
         return withCID(json({ ok: true, reply }, { headers: corsHeaders() }));
       }


### PR DESCRIPTION
## Summary
- Use Cloudflare Workers AI Gateway for chat responses and log interactions to `memory/log.json`
- Add Cloudflare configuration placeholders in `.env.example` and docs
- Expand chat action tests to verify file-based memory logging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a095cd9adc8325a5b4a100b64fbf0d