### PR TITLE
Implement session continuity retrieval and drop unused route

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "tail": "wrangler tail",
     "db:init": "wrangler d1 execute AQUIL_DB --file=schema.sql --env production",
     "db:migrate": "wrangler d1 migrations apply AQUIL_DB --env production",
-    "types": "wrangler types"
+    "types": "wrangler types",
+    "test": "node --test \"test/**/*.test.js\""
   },
   "keywords": [
     "personal-ai",

--- a/test/handleSessionInit.test.js
+++ b/test/handleSessionInit.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { handleSessionInit } from '../src/ark/endpoints.js';
+
+// utility to create fake env with stubbed DB and AI
+function createEnv(logs) {
+  return {
+    AQUIL_DB: {
+      prepare: () => ({
+        bind: () => ({
+          all: async () => ({ results: logs }),
+          run: async () => ({})
+        })
+      })
+    },
+    AI: {
+      run: async () => ({ response: 'hi' })
+    }
+  };
+}
+
+test('handleSessionInit retrieves continuity logs', async () => {
+  const fakeLogs = [
+    { id: '1', timestamp: '2024-01-01T00:00:00Z', kind: 'test', detail: '{"foo":"bar"}' }
+  ];
+  const env = createEnv(fakeLogs);
+  const res = await handleSessionInit(new Request('http://local/session-init'), env);
+  const data = await res.json();
+  assert.equal(data.continuity.length, 1);
+  assert.deepEqual(data.continuity[0], {
+    id: '1',
+    timestamp: '2024-01-01T00:00:00Z',
+    kind: 'test',
+    detail: { foo: 'bar' }
+  });
+});


### PR DESCRIPTION
## Summary
- fetch recent continuity logs from the database during session initialization
- remove unimplemented `/api/patterns/expose-contradictions` route
- add unit test for session-init continuity retrieval and wire up `npm test`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad9ab499c48325be6ded56eb2a64bf