### PR TITLE
refactor: separate ARK router

### DIFF
--- a/src/ark/endpoints.js
+++ b/src/ark/endpoints.js
@@ -1,3 +1,11 @@
+import {
+  getPhiladelphiaTime,
+  generateId,
+  logMetamorphicEvent,
+  selectOptimalVoice,
+  performHealthChecks,
+} from './core.js';
+
 // Manifest for GPT: describes all available actions and storage usage
 export const ARK_MANIFEST = [
   {
@@ -36,35 +44,6 @@ export const ARK_MANIFEST = [
     logs: true
   }
 ];
-
-// ...existing code...
-// Unified handler for ARK endpoints (for src/index.js)
-export async function handleArkEndpoints(request, env) {
-  // Route based on request URL for all ARK endpoints
-  const url = new URL(request.url);
-  if (url.pathname === '/api/session-init' || url.pathname.startsWith('/api/voice')) {
-    return handleSessionInit(request, env);
-  }
-  if (url.pathname === '/api/discovery/generate-inquiry' || url.pathname.startsWith('/api/discovery')) {
-    return handleDiscoveryInquiry(request, env);
-  }
-  if (url.pathname === '/api/ritual/auto-suggest' || url.pathname.startsWith('/api/ritual')) {
-    return handleRitualSuggestion(request, env);
-  }
-  if (url.pathname === '/api/system/health-check' || url.pathname.startsWith('/api/system/health-check')) {
-    return handleHealthCheck(request, env);
-  }
-  if (url.pathname === '/api/log' || url.pathname.startsWith('/api/log')) {
-    return handleLog(request, env);
-  }
-  return new Response('Not found', { status: 404 });
-}
-import {
-  getPhiladelphiaTime,
-  generateId,
-  logMetamorphicEvent,
-  selectOptimalVoice,
-} from './core.js';
 
 // Helper to call Worker AI (supports both env.AI and env.AI_GATEWAY)
 async function aiCall(env, model, messages) {
@@ -240,32 +219,4 @@ export async function handleLog(request, env) {
     headers: { 'Content-Type': 'application/json' }
   });
 }
-
-// Main export
-export default {
-  handleSessionInit,
-  handleDiscoveryInquiry,
-  handleRitualSuggestion,
-  handleHealthCheck,
-  handleLog
-};
-// File: src/index.js
-
-import { Router } from 'itty-router';
-
-const router = Router();
-const cors = { 'Access-Control-Allow-Origin': '*', 'Content-Type': 'application/json' };
-const addCORS = res => (Object.entries(cors).forEach(([k,v])=>res.headers.set(k,v))||res);
-
-// CORS preflight
-router.options('*', () => new Response(null, { status: 200, headers: cors }));
-
-// ARK endpoints
-router.get('/api/session-init', (req, env) => addCORS(endpoints.handleSessionInit(req, env)));
-router.post('/api/discovery/generate-inquiry', (req, env) => addCORS(endpoints.handleDiscoveryInquiry(req, env)));
-router.post('/api/ritual/auto-suggest', (req, env) => addCORS(endpoints.handleRitualSuggestion(req, env)));
-router.get('/api/system/health-check', (req, env) => addCORS(endpoints.handleHealthCheck(req, env)));
-router.post('/api/log', (req, env) => addCORS(endpoints.handleLog(req, env)));
-
-// Existing ARK and legacy endpoints follow...
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,26 +1,33 @@
+import { Router } from 'itty-router';
+import {
+  handleSessionInit,
+  handleDiscoveryInquiry,
+  handleRitualSuggestion,
+  handleHealthCheck,
+  handleLog,
+} from './ark/endpoints.js';
+
+const router = Router();
+const cors = { 'Access-Control-Allow-Origin': '*', 'Content-Type': 'application/json' };
+const addCORS = (res) => {
+  Object.entries(cors).forEach(([k, v]) => res.headers.set(k, v));
+  return res;
+};
+
+// CORS preflight
+router.options('*', () => new Response(null, { status: 200, headers: cors }));
+
+// ARK endpoints
+router.get('/api/session-init', async (req, env) => addCORS(await handleSessionInit(req, env)));
+router.post('/api/discovery/generate-inquiry', async (req, env) => addCORS(await handleDiscoveryInquiry(req, env)));
+router.post('/api/ritual/auto-suggest', async (req, env) => addCORS(await handleRitualSuggestion(req, env)));
+router.get('/api/system/health-check', async (req, env) => addCORS(await handleHealthCheck(req, env)));
+router.post('/api/log', async (req, env) => addCORS(await handleLog(req, env)));
+
+// Fallback for unknown routes
+router.all('*', () => addCORS(new Response('Not found', { status: 404 })));
+
 export default {
-    async fetch(req, env, ctx) {
-        const url = new URL(req.url);
-    }
-            new Response(JSON.stringify(data), {
-                status,
-                headers: { 'content-type': 'application/json' }
-            });
-
-        // --- Auth: Bearer token ---
-        // const auth = req.headers.get('authorization') || '';
-        // const token = auth.startsWith('Bearer ') ? auth.slice(7) : '';
-        // if (!token || token !== env.SECRET_API_KEY) return send(401, { error: 'unauthorized' });
-
-        // Helper: try to parse JSON body
-        const readJSON = async () => {
-            try { return await req.json(); } catch { return {}; }
-        };
-
-
-    // TODO: Restore legacy log/retrieve endpoint logic here
-
-        return send(404, { error: 'not_found' });
-    }
-    };
+  fetch: (request, env, ctx) => router.handle(request, env, ctx),
+};
 


### PR DESCRIPTION
## Summary
- move router and CORS setup from `ark/endpoints.js` into `index.js`
- export only pure handlers and `ARK_MANIFEST` from `ark/endpoints.js`
- reference handlers directly in router to avoid `endpoints.handle…` errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adae83af288325bdc7ec659d6b2ea6