### PR TITLE
refactor: add structured logger for Aquil core

### DIFF
--- a/src/src-core-aquil-core.js
+++ b/src/src-core-aquil-core.js
@@ -5,6 +5,7 @@
 
 import { AquilDatabase } from '../utils/database.js';
 import { AquilAI } from '../utils/ai-helpers.js';
+import { logger } from '../utils/logger.js';
 
 export class AquilCore {
   constructor(env) {
@@ -18,7 +19,7 @@ export class AquilCore {
   async initialize() {
     if (this.initialized) return;
 
-    console.log('🌱 Initializing Aquil Core System...');
+    logger.info('Initializing Aquil Core System...');
     
     // Load or create user profile
     this.userProfile = await this.db.getUserProfile();
@@ -28,7 +29,7 @@ export class AquilCore {
     }
 
     this.initialized = true;
-    console.log('✅ Aquil Core System initialized');
+    logger.info('Aquil Core System initialized');
   }
 
   async createInitialProfile() {
@@ -49,12 +50,12 @@ export class AquilCore {
     };
 
     await this.db.updateUserProfile(initialProfile);
-    console.log('✅ Initial user profile created');
+    logger.info('Initial user profile created');
   }
 
   // Daily wisdom synthesis
   async runDailySynthesis() {
-    console.log('🌅 Running daily wisdom synthesis...');
+    logger.info('Running daily wisdom synthesis...');
     
     try {
       const trustSessions = await this.db.getRecentTrustSessions(7);
@@ -64,11 +65,11 @@ export class AquilCore {
       const synthesis = await this.generateWisdomSynthesis(patterns);
       
       await this.storeWisdomCompilation(synthesis);
-      
-      console.log('✅ Daily wisdom synthesis complete');
+
+      logger.info('Daily wisdom synthesis complete');
       return synthesis;
     } catch (error) {
-      console.error('Daily synthesis error:', error);
+      logger.error('Daily synthesis error', { error: error.message });
       return null;
     }
   }
@@ -184,7 +185,7 @@ export class AquilCore {
   }
 
   async generateWisdomCompilation() {
-    console.log('📝 Generating wisdom compilation...');
+    logger.info('Generating wisdom compilation...');
     // Daily compilation logic would go here
     return { status: 'Wisdom compiled for today' };
   }

--- a/src/src-utils-logger.js
+++ b/src/src-utils-logger.js
@@ -1,0 +1,18 @@
+/**
+ * Simple structured logger without emojis
+ * Outputs JSON strings with level, message, and optional metadata
+ */
+
+export const logger = {
+  info(message, metadata = {}) {
+    console.log(
+      JSON.stringify({ level: 'info', message, ...metadata })
+    );
+  },
+  error(message, metadata = {}) {
+    console.error(
+      JSON.stringify({ level: 'error', message, ...metadata })
+    );
+  }
+};
+


### PR DESCRIPTION
## Summary
- add simple JSON logger utility
- replace `console.log`/`console.error` in Aquil core with logger

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adb0d650388325b097a78c396448b7