### PR TITLE
refactor: modularize action handlers and route by path

### DIFF
--- a/src/actions/ai.js
+++ b/src/actions/ai.js
@@ -1,0 +1,30 @@
+const send = (status, data) => new Response(JSON.stringify(data), {
+  status,
+  headers: { 'content-type': 'application/json' }
+});
+
+const readJSON = async (req) => {
+  try { return await req.json(); } catch { return {}; }
+};
+
+export async function embed(req, env) {
+  const { text, model = '@cf/baai/bge-small-en-v1.5' } = await readJSON(req);
+  if (!text) return send(400, { error: 'text required' });
+  try {
+    const out = await env.AI.run(model, { text });
+    const vector = out.data[0];
+    return send(200, { vector, dims: vector.length });
+  } catch (e) {
+    return send(500, { error: 'ai_embed_error', message: String(e) });
+  }
+}
+
+export async function generate(req, env) {
+  const { model = '@cf/meta/llama-3.1-8b-instruct', messages } = await readJSON(req);
+  try {
+    const out = await env.AI.run(model, { messages });
+    return send(200, { output: out });
+  } catch (e) {
+    return send(500, { error: 'ai_generate_error', message: String(e) });
+  }
+}

--- a/src/actions/d1.js
+++ b/src/actions/d1.js
@@ -1,0 +1,23 @@
+const send = (status, data) => new Response(JSON.stringify(data), {
+  status,
+  headers: { 'content-type': 'application/json' }
+});
+
+const readJSON = async (req) => {
+  try { return await req.json(); } catch { return {}; }
+};
+
+export async function exec(req, env) {
+  const { sql, params = [] } = await readJSON(req);
+  if (typeof sql !== 'string') return send(400, { error: 'sql required' });
+  const op = sql.trim().split(/\s+/)[0].toUpperCase();
+  if (!['SELECT', 'INSERT', 'UPDATE', 'DELETE', 'CREATE'].includes(op))
+    return send(400, { error: 'unsupported statement' });
+  try {
+    const stmt = env.DB.prepare(sql);
+    const result = params.length ? await stmt.bind(...params).all() : await stmt.all();
+    return send(200, { result });
+  } catch (e) {
+    return send(500, { error: 'd1_error', message: String(e) });
+  }
+}

--- a/src/actions/kv.js
+++ b/src/actions/kv.js
@@ -1,0 +1,24 @@
+const send = (status, data) => new Response(JSON.stringify(data), {
+  status,
+  headers: { 'content-type': 'application/json' }
+});
+
+const readJSON = async (req) => {
+  try { return await req.json(); } catch { return {}; }
+};
+
+export async function log(req, env) {
+  const { key, value, metadata, expiration } = await readJSON(req);
+  if (!key || value === undefined) return send(400, { error: 'key and value required' });
+  const body = typeof value === 'string' ? value : JSON.stringify(value);
+  await env.MEMORY_KV.put(key, body, { metadata, expiration });
+  return send(200, { ok: true, key });
+}
+
+export async function get(req, env) {
+  const url = new URL(req.url);
+  const key = url.searchParams.get('key');
+  if (!key) return send(400, { error: 'key required' });
+  const val = await env.MEMORY_KV.get(key);
+  return send(200, { key, value: val });
+}

--- a/src/actions/r2.js
+++ b/src/actions/r2.js
@@ -1,0 +1,31 @@
+const send = (status, data) => new Response(JSON.stringify(data), {
+  status,
+  headers: { 'content-type': 'application/json' }
+});
+
+const readJSON = async (req) => {
+  try { return await req.json(); } catch { return {}; }
+};
+
+export async function put(req, env) {
+  const { key, base64, httpMetadata } = await readJSON(req);
+  if (!key || !base64) return send(400, { error: 'key and base64 required' });
+  try {
+    const bytes = Uint8Array.from(atob(base64), c => c.charCodeAt(0));
+    await env.ARCHIVE_BUCKET.put(key, bytes, { httpMetadata });
+    return send(200, { ok: true, key });
+  } catch (e) {
+    return send(500, { error: 'r2_put_error', message: String(e) });
+  }
+}
+
+export async function get(req, env) {
+  const url = new URL(req.url);
+  const key = url.searchParams.get('key');
+  if (!key) return send(400, { error: 'key required' });
+  const obj = await env.ARCHIVE_BUCKET.get(key);
+  if (!obj) return send(404, { error: 'not_found' });
+  const buf = await obj.arrayBuffer();
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(buf)));
+  return send(200, { key, base64 });
+}

--- a/src/actions/vectorize.js
+++ b/src/actions/vectorize.js
@@ -1,0 +1,40 @@
+const send = (status, data) => new Response(JSON.stringify(data), {
+  status,
+  headers: { 'content-type': 'application/json' }
+});
+
+const readJSON = async (req) => {
+  try { return await req.json(); } catch { return {}; }
+};
+
+export async function upsert(req, env) {
+  const { id, text, vector, metadata, model = '@cf/baai/bge-small-en-v1.5' } = await readJSON(req);
+  let v = vector;
+  try {
+    if (!v && text) {
+      const embedding = await env.AI.run(model, { text });
+      v = embedding.data[0];
+    }
+    if (!id || !Array.isArray(v)) return send(400, { error: 'id and embedding vector required' });
+    await env.VECTORIZE.upsert([{ id, values: v, metadata }]);
+    return send(200, { ok: true, id });
+  } catch (e) {
+    return send(500, { error: 'vector_upsert_error', message: String(e) });
+  }
+}
+
+export async function query(req, env) {
+  const { text, vector, topK = 5, model = '@cf/baai/bge-small-en-v1.5' } = await readJSON(req);
+  let v = vector;
+  try {
+    if (!v && text) {
+      const embedding = await env.AI.run(model, { text });
+      v = embedding.data[0];
+    }
+    if (!Array.isArray(v)) return send(400, { error: 'vector or text required' });
+    const results = await env.VECTORIZE.query(v, { topK });
+    return send(200, { results });
+  } catch (e) {
+    return send(500, { error: 'vector_query_error', message: String(e) });
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,11 @@ import {
   handleHealthCheck,
   handleLog,
 } from './ark/endpoints.js';
+import * as kv from './actions/kv.js';
+import * as d1 from './actions/d1.js';
+import * as r2 from './actions/r2.js';
+import * as vectorize from './actions/vectorize.js';
+import * as ai from './actions/ai.js';
 
 const router = Router();
 const cors = { 'Access-Control-Allow-Origin': '*', 'Content-Type': 'application/json' };
@@ -24,15 +29,30 @@ router.post('/api/ritual/auto-suggest', async (req, env) => addCORS(await handle
 router.get('/api/system/health-check', async (req, env) => addCORS(await handleHealthCheck(req, env)));
 router.post('/api/log', async (req, env) => addCORS(await handleLog(req, env)));
 
+// KV
+router.post('/kv/log', async (req, env) => addCORS(await kv.log(req, env)));
+router.get('/kv/get', async (req, env) => addCORS(await kv.get(req, env)));
+
+// D1
+router.post('/d1/exec', async (req, env) => addCORS(await d1.exec(req, env)));
+
+// R2
+router.post('/r2/put', async (req, env) => addCORS(await r2.put(req, env)));
+router.get('/r2/get', async (req, env) => addCORS(await r2.get(req, env)));
+
+// Vectorize
+router.post('/vectorize/upsert', async (req, env) => addCORS(await vectorize.upsert(req, env)));
+router.post('/vectorize/query', async (req, env) => addCORS(await vectorize.query(req, env)));
+
+// Workers AI
+router.post('/ai/embed', async (req, env) => addCORS(await ai.embed(req, env)));
+router.post('/ai/generate', async (req, env) => addCORS(await ai.generate(req, env)));
+
 // Fallback for unknown routes
 router.all('*', () => addCORS(new Response('Not found', { status: 404 })));
 
 export default {
-  fetch: (request, env, ctx) => router.handle(request, env, ctx),
-};
-
-export default {
   fetch(request, env, ctx) {
-    return router.handle(request, env, ctx).catch((err) => send(500, err));
-  }
+    return router.handle(request, env, ctx);
+  },
 };


### PR DESCRIPTION
## Summary
- split legacy `actions.js` into focused modules for KV, D1, R2, Vectorize, and Workers AI
- add router in `index.js` to dispatch requests to new modules by path

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adb0abc82c83258ff4ab7d54d6d87a