### PR TITLE
fix: correct utility imports for core modules and add load tests

### DIFF
--- a/src/src-core-aquil-core.js
+++ b/src/src-core-aquil-core.js
@@ -3,8 +3,8 @@
  * Orchestrates all wisdom systems and maintains your personal growth journey
  */
 
-import { AquilDatabase } from '../utils/database.js';
-import { AquilAI } from '../utils/ai-helpers.js';
+import { AquilDatabase } from './src-utils-database.js';
+import { AquilAI } from './src-utils-ai-helpers.js';
 
 export class AquilCore {
   constructor(env) {

--- a/src/src-core-trust-builder.js
+++ b/src/src-core-trust-builder.js
@@ -3,8 +3,8 @@
  * Your personal companion for developing self-authority and inner knowing
  */
 
-import { AquilDatabase } from '../utils/database.js';
-import { AquilAI } from '../utils/ai-helpers.js';
+import { AquilDatabase } from './src-utils-database.js';
+import { AquilAI } from './src-utils-ai-helpers.js';
 
 export class TrustBuilder {
   constructor(env) {
@@ -545,7 +545,7 @@ export class TrustBuilder {
     }
 
     if (analysis.internal_vs_external === 'internal_focused') {
-      celebrations.push('🌟 You're primarily referencing your inner authority - this is sophisticated emotional intelligence');
+      celebrations.push('🌟 You\'re primarily referencing your inner authority - this is sophisticated emotional intelligence');
     }
 
     celebrations.push('🌱 You chose to do this trust check-in - this decision itself shows self-care and growth commitment');

--- a/test/moduleLoad.test.js
+++ b/test/moduleLoad.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const fakeEnv = { AQUIL_DB: {}, AQUIL_MEMORIES: {} };
+
+test('AquilCore module loads', async () => {
+  const { AquilCore } = await import('../src/src-core-aquil-core.js');
+  const instance = new AquilCore(fakeEnv);
+  assert.ok(instance);
+});
+
+test('TrustBuilder module loads', async () => {
+  const { TrustBuilder } = await import('../src/src-core-trust-builder.js');
+  const instance = new TrustBuilder(fakeEnv);
+  assert.ok(instance);
+});


### PR DESCRIPTION
## Summary
- fix utility imports in Aquil Core and Trust Builder to reference local src-utils files
- add unit tests ensuring Aquil Core and Trust Builder modules load correctly
- escape apostrophe in Trust Builder celebration message

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adb0826d0c8325af674924c1db2041