### PR TITLE
refactor: share http helpers

### DIFF
--- a/src/actions/ai.js
+++ b/src/actions/ai.js
@@ -1,11 +1,4 @@
-const send = (status, data) => new Response(JSON.stringify(data), {
-  status,
-  headers: { 'content-type': 'application/json' }
-});
-
-const readJSON = async (req) => {
-  try { return await req.json(); } catch { return {}; }
-};
+import { send, readJSON } from '../utils/http.js';
 
 export async function embed(req, env) {
   const { text, model = '@cf/baai/bge-small-en-v1.5' } = await readJSON(req);

--- a/src/actions/d1.js
+++ b/src/actions/d1.js
@@ -1,3 +1,5 @@
+import { send, readJSON } from '../utils/http.js';
+
 // Stub for logs endpoint
 export async function getLogs(env) {
   // Example: fetch last 10 logs from D1
@@ -8,14 +10,6 @@ export async function getLogs(env) {
     return { error: 'Unable to fetch logs', message: String(e) };
   }
 }
-const send = (status, data) => new Response(JSON.stringify(data), {
-  status,
-  headers: { 'content-type': 'application/json' }
-});
-
-const readJSON = async (req) => {
-  try { return await req.json(); } catch { return {}; }
-};
 
 export async function exec(req, env) {
   const { sql, params = [] } = await readJSON(req);

--- a/src/actions/kv.js
+++ b/src/actions/kv.js
@@ -1,11 +1,4 @@
-const send = (status, data) => new Response(JSON.stringify(data), {
-  status,
-  headers: { 'content-type': 'application/json' }
-});
-
-const readJSON = async (req) => {
-  try { return await req.json(); } catch { return {}; }
-};
+import { send, readJSON } from '../utils/http.js';
 
 export async function log(req, env) {
   const { key, value, metadata, expiration } = await readJSON(req);

--- a/src/actions/r2.js
+++ b/src/actions/r2.js
@@ -1,11 +1,4 @@
-const send = (status, data) => new Response(JSON.stringify(data), {
-  status,
-  headers: { 'content-type': 'application/json' }
-});
-
-const readJSON = async (req) => {
-  try { return await req.json(); } catch { return {}; }
-};
+import { send, readJSON } from '../utils/http.js';
 
 export async function put(req, env) {
   const { key, base64, httpMetadata } = await readJSON(req);

--- a/src/actions/vectorize.js
+++ b/src/actions/vectorize.js
@@ -1,11 +1,4 @@
-const send = (status, data) => new Response(JSON.stringify(data), {
-  status,
-  headers: { 'content-type': 'application/json' }
-});
-
-const readJSON = async (req) => {
-  try { return await req.json(); } catch { return {}; }
-};
+import { send, readJSON } from '../utils/http.js';
 
 export async function upsert(req, env) {
   const { id, text, vector, metadata, model = '@cf/baai/bge-small-en-v1.5' } = await readJSON(req);

--- a/src/utils/http.js
+++ b/src/utils/http.js
@@ -1,0 +1,13 @@
+export const send = (status, data) =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json' }
+  });
+
+export const readJSON = async (req) => {
+  try {
+    return await req.json();
+  } catch {
+    return {};
+  }
+};


### PR DESCRIPTION
## Summary
- centralize JSON response and request parsing helpers in `src/utils/http.js`
- import shared HTTP helpers across AI, KV, D1, R2, and Vectorize actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adc5a9f2f4832591cd4a5b00fd6e92