### PR TITLE
feat: standardize database env key

### DIFF
--- a/src/actions/d1.js
+++ b/src/actions/d1.js
@@ -2,7 +2,7 @@
 export async function getLogs(env) {
   // Example: fetch last 10 logs from D1
   try {
-    const results = await env.DB.prepare('SELECT * FROM logs ORDER BY timestamp DESC LIMIT 10').all();
+    const results = await env.AQUIL_DB.prepare('SELECT * FROM logs ORDER BY timestamp DESC LIMIT 10').all();
     return results.results || [];
   } catch (e) {
     return { error: 'Unable to fetch logs', message: String(e) };
@@ -24,7 +24,7 @@ export async function exec(req, env) {
   if (!['SELECT', 'INSERT', 'UPDATE', 'DELETE', 'CREATE'].includes(op))
     return send(400, { error: 'unsupported statement' });
   try {
-    const stmt = env.DB.prepare(sql);
+    const stmt = env.AQUIL_DB.prepare(sql);
     const result = params.length ? await stmt.bind(...params).all() : await stmt.all();
     return send(200, { result });
   } catch (e) {


### PR DESCRIPTION
## Summary
- use `AQUIL_DB` consistently for D1 access
- replace legacy `env.DB` references in actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adc648960c8325ad1c3dbf07502f22