### PR TITLE
refactor: replace deprecated substr usage in ID generator

### DIFF
--- a/src/ark/core.js
+++ b/src/ark/core.js
@@ -12,7 +12,7 @@ export function getPhiladelphiaTime(date = new Date()) {
 }
 
 export function generateId() {
-    return `ark_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    return `ark_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
 }
 
 export const VOICE_SYSTEM = {


### PR DESCRIPTION
## Summary
- avoid deprecated `substr` in `generateId`
- use `slice` to build random ID

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adc701f9188325ba6c15ba2d67f604