### PR TITLE
Add stub routes for all OpenAPI paths and test coverage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,25 @@ const addCORS = (res) => {
   return res;
 };
 
+// Helper to create simple placeholder POST endpoints
+const createJsonPlaceholder = (path) => {
+  router.post(path, async (req) => {
+    let data;
+    try {
+      data = await req.json();
+    } catch {
+      return addCORS(new Response(JSON.stringify({ error: 'Malformed JSON' }), {
+        status: 400,
+        headers: cors
+      }));
+    }
+    return addCORS(new Response(JSON.stringify({ message: `${path} placeholder`, input: data }), {
+      status: 200,
+      headers: cors
+    }));
+  });
+};
+
 // CORS preflight
 router.options('*', () => new Response(null, { status: 200, headers: cors }));
 
@@ -48,7 +67,7 @@ router.post('/api/trust/check-in', async (req, env) => {
   }
   try {
     const trustBuilder = new TrustBuilder(env);
-    const result = await trustBuilder.checkIn(data);
+    const result = await trustBuilder.processCheckIn(data);
     return addCORS(new Response(JSON.stringify(result), {
       status: 200,
       headers: cors
@@ -108,7 +127,7 @@ router.post('/api/patterns/recognize', async (req, env) => {
   }
   try {
     const recognizer = new PatternRecognizer(env);
-    const result = await recognizer.recognize(data);
+    const result = await recognizer.analyzePatterns(data);
     return addCORS(new Response(JSON.stringify(result), {
       status: 200,
       headers: cors
@@ -138,7 +157,7 @@ router.post('/api/standing-tall/practice', async (req, env) => {
   }
   try {
     const standingTall = new StandingTall(env);
-    const result = await standingTall.practice(data);
+    const result = await standingTall.generatePractice(data);
     return addCORS(new Response(JSON.stringify(result), {
       status: 200,
       headers: cors
@@ -156,7 +175,7 @@ router.post('/api/standing-tall/practice', async (req, env) => {
 });
 
 // Wisdom synthesis endpoint
-router.post('/api/wisdom/synthesize', async (req, env) => {
+router.post('/api/wisdom/synthesize', async (req) => {
   let data;
   try {
     data = await req.json();
@@ -166,46 +185,26 @@ router.post('/api/wisdom/synthesize', async (req, env) => {
       headers: cors
     }));
   }
-  try {
-    // Assume wisdom synthesis logic is in TrustBuilder for now
-    const trustBuilder = new TrustBuilder(env);
-    const result = await trustBuilder.synthesizeWisdom(data);
-    return addCORS(new Response(JSON.stringify(result), {
-      status: 200,
-      headers: cors
-    }));
-  } catch (error) {
-    console.error('Wisdom synthesis error:', error);
-    return addCORS(new Response(JSON.stringify({
-      error: 'Synthesis processing error',
-      message: 'Your inner wisdom is always available. Trust your body, honor your gut, accept what is, and take aligned action.'
-    }), {
-      status: 500,
-      headers: cors
-    }));
-  }
+  // Placeholder response until full wisdom synthesizer is implemented
+  return addCORS(new Response(JSON.stringify({
+    message: 'Wisdom synthesis placeholder',
+    input: data
+  }), {
+    status: 200,
+    headers: cors
+  }));
 });
 
 // Daily wisdom synthesis endpoint
-router.get('/api/wisdom/daily-synthesis', async (req, env) => {
-  try {
-    // Assume daily wisdom logic is in TrustBuilder for now
-    const trustBuilder = new TrustBuilder(env);
-    const result = await trustBuilder.dailySynthesis();
-    return addCORS(new Response(JSON.stringify(result), {
-      status: 200,
-      headers: cors
-    }));
-  } catch (error) {
-    console.error('Daily wisdom error:', error);
-    return addCORS(new Response(JSON.stringify({
-      error: 'Daily wisdom error',
-      message: 'Your wisdom journey continues even when systems are offline. Trust your inner knowing.'
-    }), {
-      status: 500,
-      headers: cors
-    }));
-  }
+router.get('/api/wisdom/daily-synthesis', async () => {
+  // Placeholder daily synthesis response
+  return addCORS(new Response(JSON.stringify({
+    message: 'Daily synthesis placeholder',
+    insights: []
+  }), {
+    status: 200,
+    headers: cors
+  }));
 });
 
 // Health endpoint
@@ -266,6 +265,21 @@ router.post('/api/somatic/session', async (req, env) => {
     }));
   }
 });
+
+// Placeholder endpoints for additional schema paths
+router.get('/api/insights', async () => addCORS(new Response(JSON.stringify({ message: '/api/insights placeholder' }), {
+  status: 200,
+  headers: cors
+})));
+
+createJsonPlaceholder('/api/feedback');
+createJsonPlaceholder('/api/dreams/interpret');
+createJsonPlaceholder('/api/energy/optimize');
+createJsonPlaceholder('/api/values/clarify');
+createJsonPlaceholder('/api/creativity/unleash');
+createJsonPlaceholder('/api/abundance/cultivate');
+createJsonPlaceholder('/api/transitions/navigate');
+createJsonPlaceholder('/api/ancestry/heal');
 
 // KV
 router.post('/kv/log', async (req, env) => addCORS(await kv.log(req, env)));

--- a/test/endpoints.test.js
+++ b/test/endpoints.test.js
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import worker from '../src/index.js';
+
+const schema = JSON.parse(fs.readFileSync(new URL('../gpt-actions-schema.json', import.meta.url)));
+
+const endpoints = [];
+for (const [path, methods] of Object.entries(schema.paths)) {
+  for (const method of Object.keys(methods)) {
+    endpoints.push({ path, method });
+  }
+}
+
+function bodyFor(path) {
+  switch (path) {
+    case '/api/log':
+      return { type: 'test', payload: {} };
+    case '/api/trust/check-in':
+      return { current_state: 'ok' };
+    case '/api/media/extract-wisdom':
+      return { media_type: 'video', title: 'x', your_reaction: 'wow' };
+    case '/api/somatic/session':
+      return { body_state: {}, emotions: [], intention: 'rest' };
+    case '/api/patterns/recognize':
+      return { area_of_focus: 'overall_growth', recent_experiences: [] };
+    case '/api/standing-tall/practice':
+      return { situation: 'test', desired_outcome: 'confidence' };
+    case '/api/wisdom/synthesize':
+      return { life_situation: 'test', specific_question: 'what now?' };
+    case '/api/feedback':
+      return { message: 'hi' };
+    case '/api/dreams/interpret':
+      return { dream_text: 'I was flying' };
+    case '/api/energy/optimize':
+      return { current_energy: 'low' };
+    case '/api/values/clarify':
+      return { values_list: ['truth'] };
+    case '/api/creativity/unleash':
+      return { block_description: 'stuck' };
+    case '/api/abundance/cultivate':
+      return { money_mindset: 'scarcity' };
+    case '/api/transitions/navigate':
+      return { transition_type: 'career' };
+    case '/api/ancestry/heal':
+      return { family_pattern: 'anger' };
+    default:
+      return { dummy: true };
+  }
+}
+
+for (const ep of endpoints) {
+  test(`${ep.method.toUpperCase()} ${ep.path} responds`, async () => {
+    const init = { method: ep.method.toUpperCase() };
+    if (ep.method === 'post') {
+      init.body = JSON.stringify(bodyFor(ep.path));
+      init.headers = { 'Content-Type': 'application/json' };
+    }
+    const res = await worker.fetch(new Request('http://localhost' + ep.path, init), {});
+    assert.notEqual(res.status, 404);
+  });
+}


### PR DESCRIPTION
## Summary
- Ensure every path in `gpt-actions-schema.json` has a matching route
- Fix mismatched handler names and add placeholder logic for wisdom synthesis
- Add automated tests that exercise each documented endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adc71347f08325b304e998238cb28a