### PR TITLE
Fix TrustBuilder check-in handler and add endpoint test

### DIFF
--- a/src/src-core-trust-builder.js
+++ b/src/src-core-trust-builder.js
@@ -13,7 +13,7 @@ export class TrustBuilder {
     this.ai = new AquilAI();
   }
 
-  async processCheckIn(data) {
+  async checkIn(data) {
     try {
       const analysis = await this.analyzeTrustState(data);
       const guidance = await this.generateTrustGuidance(analysis);

--- a/src/src-index-complete.js
+++ b/src/src-index-complete.js
@@ -48,7 +48,7 @@ router.post('/api/trust/check-in', async (request, env) => {
   }
   try {
     const trustBuilder = new TrustBuilder(env);
-    const result = await trustBuilder.processCheckIn(data);
+    const result = await trustBuilder.checkIn(data);
 
     return addCORSHeaders(new Response(JSON.stringify(result), {
       headers: { 'Content-Type': 'application/json' }

--- a/test/trustCheckIn.test.js
+++ b/test/trustCheckIn.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import worker from '../src/index.js';
+
+function createEnv() {
+  return {
+    AQUIL_DB: {
+      prepare: () => ({
+        bind: () => ({
+          all: async () => ({ results: [] }),
+          run: async () => ({})
+        })
+      })
+    },
+    AQUIL_MEMORIES: {}
+  };
+}
+
+test('trust check-in endpoint returns analysis', async () => {
+  const env = createEnv();
+  const request = new Request('http://localhost/api/trust/check-in', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ current_state: 'I trust myself', trust_level: 7 })
+  });
+  const response = await worker.fetch(request, env);
+  assert.equal(response.status, 200);
+  const data = await response.json();
+  assert.ok(data.trust_analysis);
+  assert.ok(data.message);
+});


### PR DESCRIPTION
## Summary
- rename TrustBuilder's `processCheckIn` method to `checkIn`
- ensure routes invoke the new `checkIn` method
- add tests covering the `/api/trust/check-in` endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adc88ed4b483259e8cc31fd3baa47d