### PR TITLE
Add schema validation tests for API endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.0.0",
+        "ajv": "^8.17.1",
         "wrangler": "^4.31.0"
       },
       "engines": {
@@ -1006,6 +1007,23 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1244,6 +1262,30 @@
       "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
       "dev": true
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
@@ -1399,6 +1441,13 @@
       "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-4.2.2.tgz",
       "integrity": "sha512-KegPW0l9SNPadProoFT07AB84uOqLUwzlXQ7HsqkS31WUrxkjdhcemRpTDUuetbMJ89uBtWeQSVoiEmUAu31uw=="
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -1495,6 +1544,16 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.2",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.0.0",
+    "ajv": "^8.17.1",
     "wrangler": "^4.31.0"
   },
   "repository": {

--- a/test/apiEndpoints.test.js
+++ b/test/apiEndpoints.test.js
@@ -1,0 +1,149 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import Ajv from 'ajv';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import app from '../src/index.js';
+import { TrustBuilder } from '../src/src-core-trust-builder.js';
+import { MediaWisdomExtractor } from '../src/src-core-media-wisdom.js';
+import { PatternRecognizer } from '../src/src-core-pattern-recognizer.js';
+import { StandingTall } from '../src/src-core-standing-tall.js';
+import { SomaticHealer } from '../src/src-core-somatic-healer.js';
+// Using real implementations for logging and D1 actions
+import * as d1 from '../src/actions/d1.js';
+import * as arkCore from '../src/ark/core.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const schema = JSON.parse(fs.readFileSync(join(__dirname, '..', 'gpt-actions-schema.json'), 'utf8'));
+const ajv = new Ajv();
+
+function validateResponse(path, method, data) {
+  const methodSchema = schema.paths[path]?.[method.toLowerCase()];
+  const responseSchema = methodSchema?.responses?.['200']?.content?.['application/json']?.schema || { type: 'object' };
+  const validate = ajv.compile(responseSchema);
+  assert.ok(validate(data), `Schema validation failed for ${path}: ${JSON.stringify(validate.errors)}`);
+}
+
+// basic environment stub
+const env = {
+  AQUIL_DB: {
+    prepare: () => ({
+      bind: () => ({
+        all: async () => ({ results: [] }),
+        run: async () => ({})
+      })
+    })
+  },
+  AI: { run: async () => ({ response: '{}' }) }
+};
+
+
+TrustBuilder.prototype.checkIn = async function(data) {
+  if (!data.current_state) throw new Error('current_state required');
+  return { message: 'ok' };
+};
+
+TrustBuilder.prototype.synthesizeWisdom = async function(data) {
+  if (!data.life_situation || !data.specific_question) throw new Error('missing fields');
+  return { wisdom: [] };
+};
+
+TrustBuilder.prototype.dailySynthesis = async function() {
+  return { wisdom: [] };
+};
+
+MediaWisdomExtractor.prototype.extractWisdom = async function(data) {
+  if (!data.media_type || !data.title || !data.your_reaction) throw new Error('missing fields');
+  return { insights: [] };
+};
+
+PatternRecognizer.prototype.recognize = async function(data) {
+  if (!data.area_of_focus || !data.recent_experiences) throw new Error('missing fields');
+  return { patterns: [] };
+};
+
+StandingTall.prototype.practice = async function(data) {
+  if (!data.situation || !data.desired_outcome) throw new Error('missing fields');
+  return { practice: [] };
+};
+
+SomaticHealer.prototype.generateSession = async function(data) {
+  if (!data.body_state || !data.emotions || !data.intention) throw new Error('missing fields');
+  return { session: [] };
+};
+
+const endpoints = [
+  { method: 'GET', path: '/api/health', valid: null },
+  { method: 'GET', path: '/api/logs', valid: null },
+  { method: 'GET', path: '/api/session-init', valid: null },
+  {
+    method: 'POST', path: '/api/log',
+    valid: { type: 'note', payload: { text: 'hi' } }
+  },
+  {
+    method: 'POST', path: '/api/trust/check-in',
+    valid: { current_state: 'confident' },
+    missing: {}
+  },
+  {
+    method: 'POST', path: '/api/media/extract-wisdom',
+    valid: { media_type: 'book', title: 'Test', your_reaction: 'wow' },
+    missing: { media_type: 'book', title: 'Test' }
+  },
+  {
+    method: 'POST', path: '/api/somatic/session',
+    valid: { body_state: 'tense', emotions: 'anxious', intention: 'relax' },
+    missing: { body_state: 'tense', emotions: 'anxious' }
+  },
+  {
+    method: 'POST', path: '/api/wisdom/synthesize',
+    valid: { life_situation: 'job', specific_question: 'What next?' },
+    missing: { life_situation: 'job' }
+  },
+  {
+    method: 'POST', path: '/api/patterns/recognize',
+    valid: { area_of_focus: 'trust_building', recent_experiences: 'I keep...' },
+    missing: { area_of_focus: 'trust_building' }
+  },
+  {
+    method: 'POST', path: '/api/standing-tall/practice',
+    valid: { situation: 'meeting', desired_outcome: 'speak up' },
+    missing: { situation: 'meeting' }
+  },
+  { method: 'GET', path: '/api/wisdom/daily-synthesis', valid: null }
+];
+
+for (const ep of endpoints) {
+  test(`${ep.path} success`, async () => {
+    const init = { method: ep.method };
+    if (ep.valid) {
+      init.body = JSON.stringify(ep.valid);
+      init.headers = { 'Content-Type': 'application/json' };
+    }
+    const res = await app.fetch(new Request('http://localhost' + ep.path, init), env);
+    assert.equal(res.status, 200);
+    const data = await res.json();
+    validateResponse(ep.path, ep.method, data);
+  });
+
+  if (ep.method === 'POST') {
+    test(`${ep.path} rejects malformed JSON`, async () => {
+      const res = await app.fetch(new Request('http://localhost' + ep.path, { method: 'POST', body: 'not-json' }), env);
+      assert.equal(res.status, 400);
+    });
+    if (ep.missing) {
+      test(`${ep.path} missing params`, async () => {
+        const res = await app.fetch(
+          new Request('http://localhost' + ep.path, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(ep.missing)
+          }),
+          env
+        );
+        assert.equal(res.status, 500);
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add AJV-based tests covering all /api endpoints
- validate responses against gpt-actions-schema and include malformed payload checks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adc8cae93c8325ad6fd7d306a0b05b