### PR TITLE
fix: align D1 logging with existing tables

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -14,7 +14,9 @@ const QUERY_MAP = {
     method: 'first'
   },
   insertLog: {
-    sql: 'INSERT INTO metamorphic_logs (id, kind, detail) VALUES (?, ?, ?)',
+    // Use the existing event_log table to avoid D1 errors when
+    // metamorphic_logs is not present in the schema.
+    sql: 'INSERT INTO event_log (id, type, payload) VALUES (?, ?, ?)',
     paramTypes: ['string', 'string', 'string'],
     method: 'run'
   }

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import {
   handleDiscoveryInquiry,
   handleRitualSuggestion,
   handleHealthCheck,
+  handleRetrieveLogs,
   handleLog,
 } from './ark/endpoints.js';
 import * as kv from './actions/kv.js';
@@ -56,6 +57,7 @@ router.get('/api/session-init', async (req, env) => addCORS(await handleSessionI
 router.post('/api/discovery/generate-inquiry', async (req, env) => addCORS(await handleDiscoveryInquiry(req, env)));
 router.post('/api/ritual/auto-suggest', async (req, env) => addCORS(await handleRitualSuggestion(req, env)));
 router.get('/api/system/health-check', async (req, env) => addCORS(await handleHealthCheck(req, env)));
+router.get('/api/logs', async (req, env) => addCORS(await handleRetrieveLogs(req, env)));
 router.post('/api/log', async (req, env) => addCORS(await handleLog(req, env)));
 
 
@@ -385,27 +387,6 @@ router.get('/api/health', async (req, env) => {
   }));
 });
 
-// Logs endpoint
-router.get('/api/logs', async (req, env) => {
-  try {
-    // Assume logs are fetched from D1
-    const logs = await d1.getLogs(env);
-    return addCORS(new Response(JSON.stringify(logs), {
-      status: 200,
-      headers: cors
-    }));
-  } catch (error) {
-    console.error('Logs error:', error);
-    return addCORS(new Response(JSON.stringify({
-      error: 'Logs error',
-      message: 'Unable to fetch logs.'
-    }), {
-      status: 500,
-      headers: cors
-    }));
-  }
-});
-
 // Somatic healing session endpoint
 router.post('/api/somatic/session', async (req, env) => {
   let data;
@@ -484,3 +465,5 @@ export default {
     return router.handle(request, env, ctx);
   },
 };
+
+export { ARK_MANIFEST } from './ark/endpoints.js';

--- a/test/apiEndpoints.test.js
+++ b/test/apiEndpoints.test.js
@@ -31,7 +31,8 @@ const env = {
     prepare: () => ({
       bind: () => ({
         all: async () => ({ results: [] }),
-        run: async () => ({})
+        run: async () => ({}),
+        first: async () => null
       })
     })
   },


### PR DESCRIPTION
## Summary
- insert logs into the existing `event_log` table to avoid missing-table errors
- check for `metamorphic_logs`/`event_log` before querying D1
- update test stubs for new D1 table checks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68add193adec8325baabe54fa244ecc2